### PR TITLE
fix: remove social in appendices

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -25,7 +25,6 @@ book:
       - sessions/lesson.qmd
       - sessions/what-next.qmd
   appendices:
-    - appendix/social.qmd
     - appendix/for-instructors.qmd
     - appendix/references.qmd
   page-footer:

--- a/sessions/what-next.qmd
+++ b/sessions/what-next.qmd
@@ -1,0 +1,3 @@
+# What next?
+
+{{< text_snippet wip >}}


### PR DESCRIPTION
## Description

This PR removes `social` in `_quarto.yml`, since we won't have a social in this tutorial (I'm assuming). It also adds a `what-next` file, where I imagine we can link to other relevant `rostools` tutorials and courses. 

Note: this is a stacked PR on #21 
<!-- Please delete as appropriate: -->
This PR needs a quick review.

## Checklist

- [X] Ran `just run-all`
