### PR TITLE
docs: :memo: add pre-tutorial tasks for instructors

### DIFF
--- a/appendix/for-instructors.qmd
+++ b/appendix/for-instructors.qmd
@@ -4,3 +4,18 @@ A more general guide to instructing or helping is found on the
 [Guides](https://guides.rostools.org/) website. This page has
 information relevant specifically to this course.
 
+## Pre-tutorial tasks
+
+Before the tutorial, you should do the steps below.
+
+Optional, if it doesn't already exist:
+
+-   Make a GitHub organisation for the tutorial (if one doesn't already
+    exist)
+-   Make a repository for the tutorial (if one doesn't already exist)
+
+Mandatory:
+
+-   Fetch participants' user names from the pre-survey
+-   Add everyone to the organisation and repository (or make a team that
+    has access to the repository always)


### PR DESCRIPTION
## Description

This PR adds a list of pre-tutorial tasks for instructors.

Closes #7 

<!-- Please delete as appropriate: -->
This PR needs a quick review.
