### PR TITLE
refactor: :recycle: move wip `text_snippet` to config

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -12,6 +12,7 @@ book:
   date: last-modified
   repo-url: https://github.com/rostools/tutorial-github-intro
   site-url: https://tutorial-github-intro.rostools.org
+  body-header: "{{< text_snippet wip >}}"
   chapters:
     - index.qmd
     - part: "Preamble"

--- a/index.qmd
+++ b/index.qmd
@@ -1,3 +1,1 @@
 # Welcome!
-
-{{< text_snippet wip >}}

--- a/preamble/pre-course.qmd
+++ b/preamble/pre-course.qmd
@@ -1,7 +1,5 @@
 # Pre-course tasks {#sec-pre-course}
 
-{{< text_snippet wip >}}
-
 In order to participate in this course, you must complete everything in
 this pre-course tasks section and finish with **completing the
 [survey]()** at the end. These tasks are designed to make it easier for

--- a/preamble/schedule.qmd
+++ b/preamble/schedule.qmd
@@ -1,7 +1,5 @@
 # Schedule {#sec-schedule}
 
-{{< text_snippet wip >}}
-
 The course is structured as a single participatory live-coding
 session interspersed with a few hands-on exercises. The
 *general* schedule outline is shown in the below table.

--- a/preamble/syllabus.qmd
+++ b/preamble/syllabus.qmd
@@ -1,7 +1,5 @@
 # Syllabus {#sec-syllabus}
 
-{{< text_snippet wip >}}
-
 Objectives:
 
 -   Item 1

--- a/sessions/introduction.qmd
+++ b/sessions/introduction.qmd
@@ -1,7 +1,5 @@
 # Introduction to course {#sec-introduction}
 
-{{< text_snippet wip >}}
-
 > [**Introduction slides**](../slides/introduction.html)
 
 <div>

--- a/sessions/lesson.qmd
+++ b/sessions/lesson.qmd
@@ -1,7 +1,5 @@
 # TODO: Lesson title here
 
-{{< text_snippet wip >}}
-
 <!-- TODO: Add an introduction here -->
 
 ## Learning objectives

--- a/sessions/what-next.qmd
+++ b/sessions/what-next.qmd
@@ -1,3 +1,1 @@
 # What next?
-
-{{< text_snippet wip >}}


### PR DESCRIPTION
## Description

This PR adds the wip `text_snippet` to `_quarto.yml` and removes it from the individual docs. 

<img width="698" alt="image" src="https://github.com/user-attachments/assets/ffd5cf1d-992b-425f-ba5d-222a76c39470" />


Closes #25 

<!-- Please delete as appropriate: -->
This PR needs a quick review.

## Checklist

- [X] Ran `just run-all`
