### PR TITLE
docs: :pencil2: "tutorial" -> "workshop"

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -4,6 +4,6 @@ Copyright (c) 2025 Luke W. Johnston and Signe Kirk Brødbæk
 
 <a rel="license" href="https://creativecommons.org/licenses/by/4.0/"><img src="https://i.creativecommons.org/l/by/4.0/88x31.png" alt="Creative Commons License" style="border-width:0"/></a>
 
-The tutorial material is licensed under the [Creative Commons Attribution
+The workshop material is licensed under the [Creative Commons Attribution
 4.0 International License](https://creativecommons.org/licenses/by/4.0/)
 License.

--- a/README.md
+++ b/README.md
@@ -2,17 +2,17 @@
 
 ## Description
 
-TODO: Very brief intro, motivation, and overview of tutorial.
+TODO: Very brief intro, motivation, and overview of workshop.
 
 This repository contains the lesson, lecture, and assignment material
-for the tutorial, including the website source files and other associated
-tutorial administration files.
+for the workshop, including the website source files and other associated
+workshop administration files.
 
-For more detail on the tutorial, check out the [welcome page]().
+For more detail on the workshop, check out the [welcome page]().
 
 ## Instructional Design
 
-The lectures and lessons in this tutorial are designed to be presented
+The lectures and lessons in this workshop are designed to be presented
 primarily with a participatory live-coding approach. This involves an
 instructor typing and running code in
 [RStudio](https://posit.co/products/open-source/rstudio/) in front of
@@ -20,19 +20,19 @@ the class, while the class follows along using their own computers.
 Challenges are interspersed in the lesson material, allowing
 participants to collaboratively work on smaller coding problems for a
 few minutes. All lesson materials are provided ahead of time on the
-tutorial website for participants to refer to during lectures.
+workshop website for participants to refer to during lectures.
 
 ## Lesson content
 
 The teaching material is found mainly in these locations:
 
-- `index.Rmd`: Contains the overview of the tutorial.
+- `index.Rmd`: Contains the overview of the workshop.
 - `preamble/` folder: Contains the files necessary for use before the
-    tutorial, for instance the syllabus, schedule, and pre-tutorial tasks.
-- `sessions/` folder: Contains the files used during the tutorial (e.g.
+    workshop, for instance the syllabus, schedule, and pre-workshop tasks.
+- `sessions/` folder: Contains the files used during the workshop (e.g.
     code-along material)
-- `appendix/` folder: Contains the files used to support the tutorial,
-    such as pre-tutorial tasks, code of conduct, resources, and
+- `appendix/` folder: Contains the files used to support the workshop,
+    such as pre-workshop tasks, code of conduct, resources, and
     instructions for instructors.
 - `slides/`: The lecture slides are rendered into HTML slides from
     Markdown.
@@ -42,7 +42,7 @@ follows the file and folder structure conventions from that package.
 
 ## Contributing
 
-If you are interested in contributing to the tutorial material, please
+If you are interested in contributing to the workshop material, please
 refer to the [contributing guidelines](CONTRIBUTING.md). For guidelines
 on how to be a helper or instructor, check out the [For
 Instructors](https://r-cubed.rostools.org/for-instructors.html) page.
@@ -53,7 +53,7 @@ this project, you agree to abide by its terms.
 
 ## Re-use
 
-The tutorial is largely designed to be taught in the order given, as each
+The workshop is largely designed to be taught in the order given, as each
 session builds off of the previous ones. The easiest way to use this
 material is to use it as-is, making use of the tips and instructions
 found throughout this page. The only thing you might want to make as
@@ -68,7 +68,7 @@ build your own website from the material is outside the scope of this
 document but you can find more information on Quarto's
 [Publishing](https://quarto.org/docs/publishing/) page.
 
-To help with general admin tasks of running the tutorial, there is the
+To help with general admin tasks of running the workshop, there is the
 [r3admin](https://github.com/rostools/r3admin) R package. For details of
 the license and acknowledgement of content used from sources, see the
 [license](TODO) page of the website.

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -5,7 +5,7 @@ project:
   #   - slides/*.html
 
 book:
-  title: "Introduction tutorial to GitHub"
+  title: "Introduction to GitHub"
   author: 
     - Signe Kirk Brødbæk
     - Luke W. Johnston

--- a/appendix/for-instructors.qmd
+++ b/appendix/for-instructors.qmd
@@ -2,17 +2,17 @@
 
 A more general guide to instructing or helping is found on the
 [Guides](https://guides.rostools.org/) website. This page has
-information relevant specifically to this tutorial.
+information relevant specifically to this workshop.
 
-## Pre-tutorial tasks
+## Pre-workshop tasks
 
-Before the tutorial, you should do the steps below.
+Before the workshop, you should do the steps below.
 
 Optional, if it doesn't already exist:
 
--   Make a GitHub organisation for the tutorial (if one doesn't already
+-   Make a GitHub organisation for the workshop (if one doesn't already
     exist)
--   Make a repository for the tutorial (if one doesn't already exist)
+-   Make a repository for the workshop (if one doesn't already exist)
 
 Mandatory:
 

--- a/preamble/syllabus.qmd
+++ b/preamble/syllabus.qmd
@@ -14,7 +14,7 @@ will enable you to:
 {{< include /includes/_working-with-files-objectives.qmd >}}
 {{< include /includes/_using-issues-objectives.qmd >}}
 
-Tangibly, during the tutorial we will:
+Tangibly, during the workshop we will:
 
 -   Create your own GitHub project (known as a *repository*)
 -   Create and edit text files on GitHub.
@@ -22,9 +22,9 @@ Tangibly, during the tutorial we will:
 
 ## Is this for you? {#sec-is-it-for-you}
 
-To help manage expectations and develop the material for this tutorial,
+To help manage expectations and develop the material for this workshop,
 we make a few possible assumptions about *who you are* as a participant
-in the tutorial, such as one or more of the following:
+in the workshop, such as one or more of the following:
 
 -   You want a gentle introduction to what GitHub is and how to use it.
 
@@ -36,14 +36,14 @@ in the tutorial, such as one or more of the following:
 -   You are able to and are comfortable enough with only working on files
     through a web browser interface (like GitHub's interface).
 
-While we have these assumptions to help focus the content of the tutorial,
-if you have an interest in the tutorial but don't fit any of the
+While we have these assumptions to help focus the content of the workshop,
+if you have an interest in the workshop but don't fit any of the
 assumptions, *you are still welcome to attend*! We welcome
 everyone, that is until capacity has been reached.
 
 In addition to the assumptions, we also have a fairly focused scope for
 teaching and expectations for learning. So this may also help you decide
-if this tutorial is for you.
+if this workshop is for you.
 
 -   We will only interact with GitHub from the website and from a web
     browser.

--- a/sessions/basics.qmd
+++ b/sessions/basics.qmd
@@ -12,19 +12,19 @@ Specific learning objectives are:
 
 {{< include /includes/_basics-objectives.qmd >}}
 
-## :speech_balloon: Discussion activity: Recall what you read during the pre-tutorial tasks
+## :speech_balloon: Discussion activity: Recall what you read during the pre-workshop tasks
 
 **Time: \~5 Minutes**
 
-Before we start the tutorial, we'll take some time to "prime" your
+Before we start the workshop, we'll take some time to "prime" your
 memory and activate your prior learning of what you read during the
-pre-tutorial tasks. Then after this activity, you'll again read the
-description of Git and GitHub from pre-tutorial tasks. We do this
+pre-workshop tasks. Then after this activity, you'll again read the
+description of Git and GitHub from pre-workshop tasks. We do this
 because effective learning is about retrieval, repetition, and actively
 engaging in the material. So:
 
 1.  For 1 minute, recall what you understood about Git and GitHub from
-    the pre-tutorial tasks. Think about how you'd explain it to someone
+    the pre-workshop tasks. Think about how you'd explain it to someone
     else.
 2.  For 4 minutes, pair up with your neighbour and take turns explaining
     to them what you remember, 2 minutes each.

--- a/sessions/introduction.qmd
+++ b/sessions/introduction.qmd
@@ -1,4 +1,4 @@
-# Introduction to tutorial {#sec-introduction}
+# Introduction to workshop {#sec-introduction}
 
 > [**Introduction slides**](../slides/introduction.html)
 

--- a/slides/introduction.qmd
+++ b/slides/introduction.qmd
@@ -3,4 +3,4 @@ format: r3-theme-revealjs
 search: false
 ---
 
-# Welcome to the TODO: add tutorial name
+# Welcome to the TODO: add workshop name


### PR DESCRIPTION
## Description

Since we agreed to move away from "tutorial" to avoid confusing it with diátaxis's more technical/non-interactive definition of tutorials

Q: Should we rename the repo and url as well? For now, I kept it as is.

Closes #44 

<!-- Please delete as appropriate: -->
This PR needs a quick review.

## Checklist

- [X] Ran `just run-all`
